### PR TITLE
Improve button focus outline

### DIFF
--- a/set.js
+++ b/set.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/typed-array/set');
+
+module.exports = parent;


### PR DESCRIPTION
Improve button focus visibility to meet a11y contrast and keyboard navigation expectations. Update primary/secondary button :focus styles to use a 3px solid accent color and outline-offset: 2px so the outline remains visible above box-shadows.